### PR TITLE
Fix error handler to log errors instead of throwing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -44,7 +44,7 @@ app.use((req, res, next) => {
     const message = err.message || "Internal Server Error";
 
     res.status(status).json({ message });
-    throw err;
+    console.error(err);
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- prevent the server from crashing on errors by logging them in middleware

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and for 'vite/client')*
